### PR TITLE
Fix Fees and DepositTx mapped operations

### DIFF
--- a/config.go
+++ b/config.go
@@ -200,8 +200,9 @@ func LoadConfiguration() (*configuration.Configuration, error) {
 			Symbol:   Symbol,
 			Decimals: Decimals,
 		},
-		TracePrefix:  "optrace",
-		FilterTokens: filterTokens,
+		TracePrefix:     "optrace",
+		FilterTokens:    filterTokens,
+		SupportsSyncing: true,
 	}
 
 	return config, nil

--- a/main.go
+++ b/main.go
@@ -22,6 +22,8 @@ func main() {
 		}
 		ots = append(ots, ot)
 	}
+	ots = append(ots, MintOpType)
+	// TODO(inphi): add BurnOpType
 	t.OperationTypes = ots
 
 	client, err := NewOpClient(cfg)

--- a/mapper.go
+++ b/mapper.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"math/big"
+
+	evmClient "github.com/coinbase/rosetta-geth-sdk/client"
+	RosettaTypes "github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/ethereum/go-ethereum/common"
+	EthTypes "github.com/ethereum/go-ethereum/core/types"
+
+	sdkTypes "github.com/coinbase/rosetta-geth-sdk/types"
+)
+
+var (
+	baseFeeVault = common.HexToAddress("0x4200000000000000000000000000000000000019")
+	l1FeeVault   = common.HexToAddress("0x420000000000000000000000000000000000001a")
+
+	MintOpType = "MINT"
+)
+
+// FeeOps returns the fee operations for a given transaction
+func FeeOps(tx *evmClient.LoadedTransaction) ([]*RosettaTypes.Operation, error) {
+	if tx.Transaction.IsDepositTx() {
+		return nil, nil
+	}
+
+	var receipt EthTypes.Receipt
+	if err := receipt.UnmarshalJSON(tx.Receipt.RawMessage); err != nil {
+		return nil, err
+	}
+
+	sequencerFeeAmount := new(big.Int).Set(tx.FeeAmount)
+	if tx.FeeBurned != nil {
+		sequencerFeeAmount.Sub(sequencerFeeAmount, tx.FeeBurned)
+	}
+	if receipt.L1Fee != nil {
+		sequencerFeeAmount.Sub(sequencerFeeAmount, receipt.L1Fee)
+	}
+
+	if sequencerFeeAmount == nil {
+		return nil, nil
+	}
+
+	feeRewarder := tx.Miner
+	if len(tx.Author) > 0 {
+		feeRewarder = tx.Author
+	}
+
+	ops := []*RosettaTypes.Operation{
+		{
+			OperationIdentifier: &RosettaTypes.OperationIdentifier{
+				Index: 0,
+			},
+			Type:   sdkTypes.FeeOpType,
+			Status: RosettaTypes.String(sdkTypes.SuccessStatus),
+			Account: &RosettaTypes.AccountIdentifier{
+				Address: evmClient.MustChecksum(tx.From.String()),
+			},
+			Amount: evmClient.Amount(new(big.Int).Neg(tx.Receipt.TransactionFee), sdkTypes.Currency),
+		},
+
+		{
+			OperationIdentifier: &RosettaTypes.OperationIdentifier{
+				Index: 1,
+			},
+			RelatedOperations: []*RosettaTypes.OperationIdentifier{
+				{
+					Index: 0,
+				},
+			},
+			Type:   sdkTypes.FeeOpType,
+			Status: RosettaTypes.String(sdkTypes.SuccessStatus),
+			Account: &RosettaTypes.AccountIdentifier{
+				Address: evmClient.MustChecksum(feeRewarder),
+			},
+			Amount: evmClient.Amount(sequencerFeeAmount, sdkTypes.Currency),
+		},
+
+		{
+			OperationIdentifier: &RosettaTypes.OperationIdentifier{
+				Index: 2,
+			},
+			RelatedOperations: []*RosettaTypes.OperationIdentifier{
+				{
+					Index: 0,
+				},
+			},
+			Type:   sdkTypes.FeeOpType,
+			Status: RosettaTypes.String(sdkTypes.SuccessStatus),
+			Account: &RosettaTypes.AccountIdentifier{
+				Address: baseFeeVault.Hex(),
+			},
+			// Note: The basefee is not actually burned on L2
+			Amount: evmClient.Amount(tx.FeeBurned, sdkTypes.Currency),
+		},
+
+		{
+			OperationIdentifier: &RosettaTypes.OperationIdentifier{
+				Index: 3,
+			},
+			RelatedOperations: []*RosettaTypes.OperationIdentifier{
+				{
+					Index: 0,
+				},
+			},
+			Type:   sdkTypes.FeeOpType,
+			Status: RosettaTypes.String(sdkTypes.SuccessStatus),
+			Account: &RosettaTypes.AccountIdentifier{
+				Address: l1FeeVault.Hex(),
+			},
+			Amount: evmClient.Amount(receipt.L1Fee, sdkTypes.Currency),
+		},
+	}
+
+	return ops, nil
+}
+
+func MintOps(tx *evmClient.LoadedTransaction, startIndex int) []*RosettaTypes.Operation {
+	if tx.Transaction.Mint() == nil {
+		return nil
+	}
+	return []*RosettaTypes.Operation{
+		{
+			OperationIdentifier: &RosettaTypes.OperationIdentifier{
+				Index: int64(startIndex),
+			},
+			Type:   MintOpType,
+			Status: RosettaTypes.String(sdkTypes.SuccessStatus),
+			Account: &RosettaTypes.AccountIdentifier{
+				Address: tx.From.String(),
+			},
+			Amount: evmClient.Amount(tx.Transaction.Mint(), sdkTypes.Currency),
+		},
+	}
+}


### PR DESCRIPTION
- This fixes the accounting of rollup fees. Fees on L2 have 3 recipients documented [here](https://github.com/ethereum-optimism/optimism/blob/d8e328ae936c6a5f3987c04cbde7bd94403a96a0/specs/predeploys.md#sequencerfeevault).
- A new operation type "MINT" is introduced to represent ETH minted on L2 via Deposit Transactions.